### PR TITLE
Wrap `deviceCall` in `setImmediate`.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -250,7 +250,7 @@ function deviceCallChain(id, commands, finally_fn) {
     }
 }
 
-function deviceCall(deviceId, commands) {
+const deviceCall = (deviceId, commands) => setImmediate(() => {
     let selectedDeviceIds = deviceIds;
 
     if (typeof deviceId === 'string') {
@@ -272,4 +272,4 @@ function deviceCall(deviceId, commands) {
             detail: err.message || err
         });
     });
-}
+});


### PR DESCRIPTION
For some reason, in the production build of the app, the commands were not actually going through...
possibly related to https://github.com/atom/electron/issues/1966? ...so I wrapped `deviceCall` in a
`setImmediate`, and everything works great. :)